### PR TITLE
Add `output` option with default to `dist`.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,1 @@
 node_modules
-packages
-todo

--- a/src/entry.webpack.config.js
+++ b/src/entry.webpack.config.js
@@ -23,9 +23,14 @@ const targetData = (target) => {
   }
 };
 
+const normalize = (root, base) => {
+  return base.charAt(0) === '/' ? base : path.join(root, base);
+};
+
 export default ({
   name,
   root = path.dirname(nearest('package.json')),
+  output = path.join('dist', name),
 }) => (config) => partial(config, {
   entry: {
     [name]: path.join(root, 'entry', `${name}.entry.js`),
@@ -34,7 +39,7 @@ export default ({
   // Output controls the settings for file generation.
   output: {
     filename: '[name].js',
-    path: path.join(root, 'build', name),
+    path: normalize(root, output),
     chunkFilename: '[id].js',
   },
   plugins: [


### PR DESCRIPTION
Now you can control where you files get output to, and the default is now the more common `dist` folder.
